### PR TITLE
Changement de l'URL de T411

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Simply run :
 node server.js 
 ```
 Then the proxy is listening on the port specified
-It will try to connect to http://api.t411.io/ to obtain a token with the credentials set in the server.js file
+It will try to connect to http://api.t411.ch/ to obtain a token with the credentials set in the server.js file
 
 Now you can configure Sonarr to use this proxy to make requests to T411
 ![Settings Window](https://raw.github.com/KiLMaN/T411-Torznab/screenshots/T411-Torznab-Sonarr-Configuration.png)

--- a/server.js
+++ b/server.js
@@ -34,8 +34,8 @@ var DEFAULT_LIMIT = 50;
 var TVRAGE_CACHE_MINS = 300; // 5Hours
 
 // System variables
-var baseUrl = "http://api.t411.in";
-var baset411 = "https://www.t411.in";
+var baseUrl = "http://api.t411.ch";
+var baset411 = "https://www.t411.ch";
 var userToken = ""; // Holds the user token for the T411 API
 
 var _T411_CatTVShow = {name:"Série TV", idCat : 0};


### PR DESCRIPTION
Passage de l'URL de t411 à t411.ch (déjà active)
